### PR TITLE
Setup Flask for serving API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,162 @@
+## Flask & python gitignores
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,45 @@
+# api
+
+This is the Flask backend.
+
+This will provide the web APIs for gw2skirmish. Currently just serves results in simple html pages.
+
+# Setup
+
+## Requisites
+- Python 3.7 at least
+
+## Environment setup (optional)
+Set up a Python virtual environment.
+- You're IDE may ask to do this for you, let it do so if you'd prefer 
+```sh
+# assuming you're in the repo root folder (not in ./api)
+
+python3 -m venv venv
+```
+If `python3` is missing `python` should work as long as it's 3.7+
+
+Activate environment
+```
+source venv/bin/activate
+```
+
+Install requirements
+```
+pip install -r api/requirements.txt
+```
+
+## Run app
+Run flask app locally
+```
+cd api
+flask run 
+```
+
+Launches web app at http://127.0.0.1:5000 
+- Launches in debug mode with automatic reload on changes
+
+
+
+
+

--- a/api/anet.py
+++ b/api/anet.py
@@ -1,0 +1,20 @@
+import json
+import requests
+
+def get_matches():
+    return fetch('wvw/matches')
+
+def get_worlds():
+    return fetch('worlds')
+
+def get_world_by_id(worlds=None):
+    if worlds is None:
+        worlds = get_worlds()
+    world_by_id = {item['id']: item for item in worlds}
+    return world_by_id
+
+def fetch(resource):
+    url = f'https://api.guildwars2.com/v2/{resource}?ids=all'
+    r = requests.get(url)
+    # TODO: cache/persist response
+    return r.json()

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,23 @@
+from flask import Flask, render_template
+from datetime import datetime, timezone
+
+from anet import get_matches,get_worlds,get_world_by_id
+
+app = Flask(__name__)
+
+@app.route('/')
+@app.route('/index/')
+def hello():
+    matches = get_matches()
+    worlds = get_worlds()
+    worlds_by_id = get_world_by_id(worlds)
+    now_utc = datetime.now(timezone.utc)
+    return render_template('homepage.html', matches=matches,now_utc=now_utc,worlds=worlds,worlds_by_id=worlds_by_id)
+
+@app.route('/world/<int:world_id>')
+def about(world_id):
+    worlds_by_id = get_world_by_id()
+    if world_id in worlds_by_id:
+        return render_template('world.html', world=worlds_by_id[world_id])
+       
+    return render_template('404.html'), 404

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,11 @@
+certifi==2022.12.7
+charset-normalizer==3.1.0
+click==8.1.3
+Flask==2.2.3
+idna==3.4
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.2
+requests==2.28.2
+urllib3==1.26.15
+Werkzeug==2.2.3

--- a/api/templates/404.html
+++ b/api/templates/404.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404</title>
+</head>
+<body>
+    <p>Oops, lost in the Tangled Depths again.</p>
+</body>
+</html>

--- a/api/templates/homepage.html
+++ b/api/templates/homepage.html
@@ -1,0 +1,182 @@
+{% from 'macros.html' import world_title %}<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>gw2skirmish</title>
+    <link rel="stylesheet" href="https://cdn.simplecss.org/simple.min.css" />
+    <style>
+      .red {
+        color: #ee0000;
+      }
+      .blue {
+        color: #6161ff;
+      }
+      .green {
+        color: #008a00;
+      }
+      @media (prefers-color-scheme: dark) {
+        .red {
+          color: #ff7878;
+        }
+        .blue {
+          color: #7878ff;
+        }
+        .green {
+          color: #78ff78;
+        }
+      }
+    </style>
+  </head>
+  <body class="main">
+    <header>
+      <h1 id="#">gw2skirmish</h1>
+      <p>Last updated: <span class="utcToLocal">{{now_utc}}</span></p>
+      <p>
+        <a href="https://github.com/MikaMika/gw2skirmish">Link to GitHub</a>
+      </p>
+    </header>
+    <nav>
+      <div id="matches">
+        <h2>matches</h2>
+        <ul>
+          {% for match in matches %}
+          <li><a href="#{{ match.id }}">{{ match.id }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+      <div id="worlds">
+        <h2>worlds</h2>
+        <div class="region" id="north-america">
+          <h3>north america 🇺🇸</h3>
+          <ul>
+            {% for world in worlds %} {% if world.id < 2000 %}
+            <li>
+              <a href="#{{ world.id }}">{{world_title(world)}}</a>
+            </li>
+            {% endif %} {% endfor %}
+          </ul>
+        </div>
+        <div class="region" id="europe">
+          <h3>europe 🇪🇺</h3>
+          <ul>
+            <li>
+              english 🇬🇧
+              <ul>
+                {% for world in worlds %} {% if world.id >= 2000 and world.id <=
+                2100 %}
+                <li>
+                  <a href="#{{ world.id }}">{{world_title(world)}}</a>
+                </li>
+                {% endif %} {% endfor %}
+              </ul>
+            </li>
+
+            <li>
+              french 🇫🇷
+              <ul>
+                {% for world in worlds %} {% if world.id >= 2100 and world.id <=
+                2200 %}
+                <li>
+                  <a href="#{{ world.id }}">{{world_title(world)}}</a>
+                </li>
+                {% endif %} {% endfor %}
+              </ul>
+            </li>
+
+            <li>
+              german 🇩🇪
+              <ul>
+                {% for world in worlds %} {% if world.id >= 2200 and world.id <=
+                2300 %}
+                <li>
+                  <a href="#{{ world.id }}">{{world_title(world)}}</a>
+                </li>
+                {% endif %} {% endfor %}
+              </ul>
+            </li>
+
+            <li>
+              spanish 🇪🇸
+              <ul>
+                {% for world in worlds %} {% if world.id >= 2300 and world.id <=
+                2400 %}
+                <li>
+                  <a href="#{{ world.id }}">{{world_title(world)}}</a>
+                </li>
+                {% endif %} {% endfor %}
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <main>
+      <div id="results">
+        <h2>results // TODO: compute results (pending)</h2>
+        {% for match in matches %}
+        <article class="match">
+          <h3 id="{{match.id}}">{{match.id}}</h3>
+          <p>
+            Skirmishes completed: {{match.skirmishes|length}}/84<br />
+            Skirmishes left: {{84 - match.skirmishes|length}}<br />
+            Max earnable VP difference: 
+          </p>
+          <div
+            class="rbg"
+            style="
+              display: flex;
+              justify-content: space-between;
+              align-items: flex-end;
+            "
+          >
+
+            
+
+            <p>
+              <b class="green" id="{{match['all_worlds']['green'][0]}}">{{world_title(worlds_by_id[match['all_worlds']['green'][0]])}}</b><br />
+              <b class="green" id="{{match['all_worlds']['green'][1]}}">{{world_title(worlds_by_id[match['all_worlds']['green'][1]]|default("N/A"))}}</b><br />
+              Victory Points: <br />
+              Victory Ratio: <br />
+              🟢🥇 vs 🔴🥈: <br />
+              Homestretch: <br />
+              Difficulty: % - %<br />
+              Certitude: %<br />
+              Prediction: 
+            </p>
+            <p>
+              <b class="red" id="{{match['all_worlds']['red'][0]}}">{{world_title(worlds_by_id[match['all_worlds']['red'][0]])}}</b><br />
+              <b class="red" id="{{match['all_worlds']['green'][1]}}">{{world_title(worlds_by_id[match['all_worlds']['red'][1]]|default("N/A"))}}</b><br />
+              Victory Points: <br />
+              Victory Ratio: %<br />
+              🔴🥈 vs 🔵🥉: <br />
+              Homestretch: <br />
+              Difficulty: % - %<br />
+              Certitude: %<br />
+              Prediction: 
+            </p>
+            <p>
+              <b class="blue" id="{{match['all_worlds']['blue'][0]}}">{{world_title(worlds_by_id[match['all_worlds']['blue'][0]])}}</b><br />
+              <b class="blue" id="{{match['all_worlds']['blue'][1]}}">{{world_title(worlds_by_id[match['all_worlds']['blue'][1]]|default("N/A"))}}</b><br />
+              Victory Points: <br />
+              Victory Ratio: %<br />
+              🔵🥉 vs 🟢🥇: <br />
+              Homestretch: <br />
+              Difficulty: % - %<br />
+              Certitude: %<br />
+              Prediction: 
+            </p>
+          </div>
+          <p><a href="#">⬆️Return to top</a></p>
+        </article>
+        {% endfor %}
+      </div>
+    </main>
+    <footer></footer>
+    <script>
+      // convert UTC time to local time for user on browser
+      document.querySelectorAll(".utcToLocal").forEach(function (i) {
+        i.innerText = new Date(i.innerText); //.toLocaleString();
+      });
+    </script>
+  </body>
+</html>

--- a/api/templates/macros.html
+++ b/api/templates/macros.html
@@ -1,0 +1,9 @@
+{% macro world_title(world) %}
+    <span class="{{world.id}}">
+        {{ world.id }} {% if world.population == "Full" %}🟥{% endif
+            %} {% if world.population == "VeryHigh" %}🟧{% endif %} {%
+            if world.population == "High" %}🟨{% endif %} {% if
+            world.population == "Medium" %}🟩{% endif %} {{ world.name
+            }}
+    </span>
+{% endmacro %}

--- a/api/templates/world.html
+++ b/api/templates/world.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WvW World: {{world.name}}</title>
+</head>
+<body>
+    <h1>WvW World: {{world.name}}</h1>
+    <p>Population: {{world.population}}</p>
+    <h3>Current Matchup</h3>
+</body>
+</html>


### PR DESCRIPTION
This bootstraps flask for use in serving the web API. 

We can also use it to serve the github.io page by freezing the generated html page.

This change creates a homepage, and subpages that should help learn how to use flask. It also implements some of the logic the bash script did using python and the jinja templates (flask's html templating). 

Does not disrupt existing code.