### PR TITLE
Add ChatGPT match analysis+prediction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,9 +154,6 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+
+.vercel/

--- a/api/app.py
+++ b/api/app.py
@@ -1,10 +1,12 @@
 from flask import Flask, render_template
 from datetime import datetime, timezone
 
-from .anet import get_matches,get_worlds,get_world_by_id
+from .anet import get_matches, get_worlds, get_world_by_id
+from .gpt_math import gpt_calculate_scores
 from .match_math import calculate_scores
 
 app = Flask(__name__)
+
 
 @app.route('/')
 @app.route('/index/')
@@ -12,14 +14,25 @@ def hello():
     matches = get_matches()
     worlds = get_worlds()
     worlds_by_id = get_world_by_id(worlds)
-    calculate_scores(matches,worlds_by_id)
+    calculate_scores(matches, worlds_by_id)
     now_utc = datetime.now(timezone.utc)
-    return render_template('homepage.html', matches=matches,now_utc=now_utc,worlds=worlds,worlds_by_id=worlds_by_id)
+    return render_template('homepage.html', matches=matches, now_utc=now_utc, worlds=worlds, worlds_by_id=worlds_by_id)
+
+
+@app.route('/gpt')
+def gpt():
+    matches = get_matches()
+    worlds = get_worlds()
+    worlds_by_id = get_world_by_id(worlds)
+    gpt_calculate_scores(matches)
+    now_utc = datetime.now(timezone.utc)
+    return render_template('gptpage.html', matches=matches, now_utc=now_utc, worlds=worlds, worlds_by_id=worlds_by_id)
+
 
 @app.route('/world/<int:world_id>')
 def about(world_id):
     worlds_by_id = get_world_by_id()
     if world_id in worlds_by_id:
         return render_template('world.html', world=worlds_by_id[world_id])
-       
+
     return render_template('404.html'), 404

--- a/api/gpt_math.py
+++ b/api/gpt_math.py
@@ -1,0 +1,149 @@
+# I asked ChatGPT to do the math for us
+
+"""
+ChatGPT Prompt:
+
+A game has 3 teams (green, red and blue) playing 1 match. the match has 84 skirmishes.
+For each skirmish each team can g get 5, 4 or 3 points.
+
+Based on this data, write a python script that calculates the following values for each team: victory point ratio,
+how many points they need to secure first place, points needed to secure second place,
+a prediction of the team's final points, how many points they need to beat the other teams,
+difficulty to win, and certainty of prediction.
+It should also calculate point differences in this manner: green vs red, red vs blue and blue vs green and use negative
+values if the points are lower for the first operand
+
+And use this results as an example for the script
+Skirmishes played = 33
+Team Green points = 145
+Team Red points = 123
+Team Blue points = 116
+"""
+
+
+def gpt_calculate_scores(matches):
+    if matches is None or matches == []:
+        return
+    for match in matches:
+        gpt_calculate_match(match)
+
+
+def gpt_calculate_match(match):
+    skirmishes_played = len(match["skirmishes"])
+    green_points = match["victory_points"]["green"]
+    red_points = match["victory_points"]["red"]
+    blue_points = match["victory_points"]["blue"]
+
+    # START of GPT code
+    # The code has not been modified in any way from the original output
+    # Constants
+    total_skirmishes = 84
+
+    # Calculate average points per skirmish for each team
+    green_avg = green_points / skirmishes_played
+    red_avg = red_points / skirmishes_played
+    blue_avg = blue_points / skirmishes_played
+
+    # Calculate remaining skirmishes
+    remaining_skirmishes = total_skirmishes - skirmishes_played
+
+    # Project final points for each team
+    green_final = green_points + green_avg * remaining_skirmishes
+    red_final = red_points + red_avg * remaining_skirmishes
+    blue_final = blue_points + blue_avg * remaining_skirmishes
+
+    # Calculate victory point ratios
+    green_vp_ratio = green_points / (skirmishes_played * 5)
+    red_vp_ratio = red_points / (skirmishes_played * 5)
+    blue_vp_ratio = blue_points / (skirmishes_played * 5)
+
+    # Calculate points needed to secure first and second place
+    green_needed_first = max(red_final, blue_final) - green_points
+    green_needed_second = min(red_final, blue_final) - green_points
+    red_needed_first = max(green_final, blue_final) - red_points
+    red_needed_second = min(green_final, blue_final) - red_points
+    blue_needed_first = max(green_final, red_final) - blue_points
+    blue_needed_second = min(green_final, red_final) - blue_points
+
+    # Calculate the difficulty to win
+    green_difficulty = green_needed_first / remaining_skirmishes
+    red_difficulty = red_needed_first / remaining_skirmishes
+    blue_difficulty = blue_needed_first / remaining_skirmishes
+
+    # Calculate point differences
+    green_red_diff = green_points - red_points
+    red_blue_diff = red_points - blue_points
+    blue_green_diff = blue_points - green_points
+
+    # Calculate certainty of prediction
+    certainty = (skirmishes_played / total_skirmishes) * 100
+
+    # Print results
+    # print("Green team:")
+    # print(f"Victory Point Ratio: {green_vp_ratio:.2f}")
+    # print(f"Points needed to secure first place: {green_needed_first:.2f}")
+    # print(f"Points needed to secure second place: {green_needed_second:.2f}")
+    # print(f"Predicted final points: {green_final:.2f}")
+    # print(f"Difficulty to win: {green_difficulty:.2f}\n")
+    #
+    # print("Red team:")
+    # print(f"Victory Point Ratio: {red_vp_ratio:.2f}")
+    # print(f"Points needed to secure first place: {red_needed_first:.2f}")
+    # print(f"Points needed to secure second place: {red_needed_second:.2f}")
+    # print(f"Predicted final points: {red_final:.2f}")
+    # print(f"Difficulty to win: {red_difficulty:.2f}\n")
+    #
+    # print("Blue team:")
+    # print(f"Victory Point Ratio: {blue_vp_ratio:.2f}")
+    # print(f"Points needed to secure first place: {blue_needed_first:.2f}")
+    # print(f"Points needed to secure second place: {blue_needed_second:.2f}")
+    # print(f"Predicted final points: {blue_final:.2f}")
+    # print(f"Difficulty to win: {blue_difficulty:.2f}\n")
+    #
+    # print(f"Green vs Red point difference: {green_red_diff}")
+    # print(f"Red vs Blue point difference: {red_blue_diff}")
+    # print(f"Blue vs Green point difference: {blue_green_diff}")
+    #
+    # print(f"Certainty of prediction: {certainty:.2}%")
+
+    # End of GPT code (commenting out the prints, adding values below)
+
+    # refactoring results add results to match
+    green = {
+        "colour": "green",
+        "victory_points": green_points,
+        "victory_point_ratio": format(green_vp_ratio, ".2f"),
+        "points_needed_first": format(green_needed_first, ".0f"),
+        "points_needed_second": format(green_needed_second, ".0f"),
+        "predicted_final_points": format(green_final, ".0f"),
+        "difficulty_to_win": format(green_difficulty, ".2f"),
+        "vs_point_diff": format(green_red_diff, ".0f"),
+    }
+    red = {
+        "colour": "red",
+        "victory_points": red_points,
+        "victory_point_ratio": format(red_vp_ratio, ".2f"),
+        "points_needed_first": format(red_needed_first, ".0f"),
+        "points_needed_second": format(red_needed_second, ".0f"),
+        "predicted_final_points": format(red_final, ".0f"),
+        "difficulty_to_win": format(red_difficulty, ".2f"),
+        "vs_point_diff": format(red_blue_diff, ".0f"),
+    }
+    blue = {
+        "colour": "blue",
+        "victory_points": blue_points,
+        "victory_point_ratio": format(blue_vp_ratio, ".2f"),
+        "points_needed_first": format(blue_needed_first, ".0f"),
+        "points_needed_second": format(blue_needed_second, ".0f"),
+        "predicted_final_points": format(blue_final, ".0f"),
+        "difficulty_to_win": format(blue_difficulty, ".2f"),
+        "vs_point_diff": format(blue_green_diff, ".0f")
+    }
+    match["results"] = [
+        green,
+        red,
+        blue,
+    ]
+    match["certainty"] = format(certainty, ".2f")
+    match['max_earnable_vp'] = remaining_skirmishes * 5
+    match['min_earnable_vp'] = remaining_skirmishes * 3

--- a/api/static/css/main.css
+++ b/api/static/css/main.css
@@ -1,0 +1,49 @@
+.red {
+    color: #ee0000;
+}
+
+.blue {
+    color: #6161ff;
+}
+
+.green {
+    color: #008a00;
+}
+
+@media (prefers-color-scheme: dark) {
+    .red {
+        color: #ff7878;
+    }
+
+    .blue {
+        color: #7878ff;
+    }
+
+    .green {
+        color: #78ff78;
+    }
+}
+
+
+.menu-bar {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 50px;
+}
+
+.menu-item {
+    list-style-type: none;
+    margin: 0 15px;
+}
+
+.menu-item a {
+    color: #fff;
+    text-decoration: none;
+    font-size: 18px;
+    transition: color 0.3s;
+}
+
+.menu-item a:hover {
+    color: #f1c40f;
+}

--- a/api/templates/gptpage.html
+++ b/api/templates/gptpage.html
@@ -1,4 +1,4 @@
-{% from 'macros.html' import world_title %}<!DOCTYPE html>
+{% from 'macros.html' import world_title %}<!DOCTYPE html><!-- TODO: use template inheritance to reduce code duplication -->
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -8,7 +8,7 @@
   </head>
   <body class="main">
     <header>
-      <h1 id="#">gw2skirmish</h1>
+      <h1 id="#">gw2skirmish - AI-powered Insights</h1>
       <p>Last updated: <span class="utcToLocal">{{now_utc}}</span></p>
       <nav class="menu-bar">
         <ul>
@@ -108,7 +108,8 @@
           <p>
             Skirmishes completed: {{match.skirmishes|length}}/84<br />
             Skirmishes left: {{84 - match.skirmishes|length}}<br />
-            Max earnable VP difference: {{match['results']['max_earnable_vp']}}
+            Max earnable VP difference: {{ match['max_earnable_vp'] }} <br/>
+            Prediction Certainty: {{ match['certainty'] }}%<br />
           </p>
           <div
             class="rbg"
@@ -118,54 +119,28 @@
               align-items: flex-end;
             "
           >
-            <p>
-              <b class="green" id="{{match['all_worlds']['green'][0]}}"
-                >{{world_title(worlds_by_id[match['all_worlds']['green'][0]])}}</b
+              {% for result in match['results'] %}
+                  <p>
+              <b class="{{result['colour']}}" id="{{match['all_worlds'][result['colour']][0]}}"
+                >{{world_title(worlds_by_id[match['all_worlds'][result['colour']][0]])}}</b
               ><br />
-              <b class="green" id="{{match['all_worlds']['green'][1]}}"
-                >{{world_title(worlds_by_id[match['all_worlds']['green'][1]]|default("N/A"))}}</b
+              <b class="{{result['colour']}}" id="{{match['all_worlds'][result['colour']][1]}}"
+                >{{world_title(worlds_by_id[match['all_worlds'][result['colour']][1]]|default("N/A"))}}</b
               ><br />
-              Victory Points: {{match['results']['first_vp']}}<br />
-              Victory Ratio: {{match['results']['first_vp_ratio']}}<br />
-              Prediction: {{match['results']['first_prediction']}}<br /><br />
-              🟢🥇 vs 🔴🥈: {{match['results']['first_point_diff']}}<br />
-              Homestretch: {{match['results']['first_tie']}}<br />
-              Difficulty: {{match['results']['first_difficulty']}}% -
-              {{match['results']['second_difficulty_max']}}%<br />
-              Certitude: {{match['results']['first_certitude']}}%<br />
+              Victory Points: {{ result['victory_points'] }}<br />
+              Victory Ratio: {{ result['victory_point_ratio'] }}<br />
+              <b>Prediction: {{ result['predicted_final_points'] }}</b><br /><br />
+              Points for First: {{ result['points_needed_first'] }}<br />
+              Points for Second: {{ result['points_needed_second'] }}<br />
+                      <br />
+              {% if result['colour'] == 'green' %}🟢🥇 vs 🔴🥈:{% endif %}
+              {% if result['colour'] == 'red' %}🔴🥈 vs 🔵🥉:{% endif %}
+              {% if result['colour'] == 'blue' %}🔵🥉 vs 🟢🥇:{% endif %}
+              {{ result['vs_point_diff'] }}<br />
+
+              Difficulty: {{ result['difficulty_to_win'] }}<br />
             </p>
-            <p>
-              <b class="red" id="{{match['all_worlds']['red'][0]}}"
-                >{{world_title(worlds_by_id[match['all_worlds']['red'][0]])}}</b
-              ><br />
-              <b class="red" id="{{match['all_worlds']['green'][1]}}"
-                >{{world_title(worlds_by_id[match['all_worlds']['red'][1]]|default("N/A"))}}</b
-              ><br />
-              Victory Points: {{match['results']['second_vp']}}<br />
-              Victory Ratio: {{match['results']['second_vp_ratio']}}%<br />
-              Prediction: {{match['results']['second_prediction']}}<br /><br />
-              🔴🥈 vs 🔵🥉: {{match['results']['second_point_diff']}}<br />
-              Homestretch: {{match['results']['second_tie']}}<br />
-              Difficulty: {{match['results']['second_difficulty']}}% -
-              {{match['results']['second_difficulty_max']}}%<br />
-              Certitude: {{match['results']['second_certitude']}}%<br />
-            </p>
-            <p>
-              <b class="blue" id="{{match['all_worlds']['blue'][0]}}"
-                >{{world_title(worlds_by_id[match['all_worlds']['blue'][0]])}}</b
-              ><br />
-              <b class="blue" id="{{match['all_worlds']['blue'][1]}}"
-                >{{world_title(worlds_by_id[match['all_worlds']['blue'][1]]|default("N/A"))}}</b
-              ><br />
-              Victory Points: {{match['results']['third_vp']}}<br />
-              Victory Ratio: {{match['results']['third_vp_ratio']}}%<br />
-              Prediction: {{match['results']['third_prediction']}}<br /><br />
-              🔵🥉 vs 🟢🥇: {{match['results']['third_point_diff']}}<br />
-              Homestretch: {{match['results']['third_tie']}}<br />
-              Difficulty: {{match['results']['third_difficulty']}}% -
-              {{match['results']['second_difficulty_max']}}%<br />
-              Certitude: {{match['results']['third_certitude']}}%<br />
-            </p>
+              {% endfor %}
           </div>
           <p><a href="#">⬆️Return to top</a></p>
         </article>


### PR DESCRIPTION
Creates a new separate page at  /gpt with ChatGPT powered analysis

Adds a link on the main page to visit that page.

The function in use `def gpt_calculate_match(match):` mostly contains ChatGPT code as-is with 0 modifications (see START and END). 

This was what I asked it to write code for:

> A game has 3 teams (green, red and blue) playing 1 match. the match has 84 skirmishes.
For each skirmish each team can g get 5, 4 or 3 points.
Based on this data, write a python script that calculates the following values for each team: victory point ratio,
how many points they need to secure first place, points needed to secure second place,
a prediction of the team's final points, how many points they need to beat the other teams,
difficulty to win, and certainty of prediction.
It should also calculate point differences in this manner: green vs red, red vs blue and blue vs green and use negative
values if the points are lower for the first operand
And use this results as an example for the script
Skirmishes played = 33
Team Green points = 145
Team Red points = 123
Team Blue points = 116