### PR TITLE
Fix team ordering mismatch

### DIFF
--- a/api/gpt_math.py
+++ b/api/gpt_math.py
@@ -108,6 +108,8 @@ def gpt_calculate_match(match):
 
     # End of GPT code (commenting out the prints, adding values below)
 
+    # TODO: point diff should be based on position eg 1vs2, 2vs3, 3vs1 and not colours as GPT was advised, update gpt prompt
+
     # refactoring results add results to match
     green = {
         "colour": "green",
@@ -139,11 +141,13 @@ def gpt_calculate_match(match):
         "difficulty_to_win": format(blue_difficulty, ".2f"),
         "vs_point_diff": format(blue_green_diff, ".0f")
     }
-    match["results"] = [
-        green,
-        red,
-        blue,
-    ]
+    team_results = [red, green, blue]
+
+    # order teamlist by victory_points
+    match['results'] = sorted(team_results, key=lambda x: x["victory_points"], reverse=True)
+    
+    #team_results.sort(key=lambda x: x['victory_points'], reverse=True)
+
     match["certainty"] = format(certainty, ".2f")
     match['max_earnable_vp'] = remaining_skirmishes * 5
     match['min_earnable_vp'] = remaining_skirmishes * 3

--- a/api/match_math.py
+++ b/api/match_math.py
@@ -95,40 +95,44 @@ def calculate_scores(matches, worlds_by_id):
         )
         third_certitude = 2 * (third_difficulty - 50)
 
-        # save calculated results for the match
-        # format floats to appropriate demical places
-        match["results"] = {}
-        match["results"]["remaining_skirmishes"] = remaining_skirmishes
-        match["results"]["remaining_vp"] = vp_remaining
-        match["results"]["max_earnable_vp"] = max_earnable_vp
-
-        match["results"]["first_vp"] = first_vp
-        match["results"]["first_point_diff"] = first_point_diff
-        match["results"]["first_vp_ratio"] = format(first_vp_ratio,".2f")
-        match["results"]["first_tie"] = format(first_tie,".2f")
-        match["results"]["first_secure"] = first_secure
-        match["results"]["first_difficulty"] = format(first_difficulty,".0f")
-        match["results"]["first_difficulty_max"] = format(100-first_difficulty,".0f")
-        match["results"]["first_prediction"] = format(first_prediction,".0f")
-        match["results"]["first_certitude"] = format(first_certitude,".2f")
+        team_results = [
+            {
+                "colour": first,
+                "victory_points": first_vp,
+                "point_diff": first_point_diff,
+                "vs_team": second,
+                "vp_ratio": format(first_vp_ratio,".2f"),
+                "tie": format(first_tie,".2f"),
+                "secure": first_secure,
+                "difficulty": format(first_difficulty,".0f"),
+                "certitude": format(first_certitude,".0f"),
+                "prediction": format(first_prediction,".0f"),
+            },
+            {
+                "colour": second,
+                "victory_points": second_vp,
+                "point_diff": second_point_diff,
+                "vs_team": third,
+                "vp_ratio": format(second_vp_ratio,".2f"),
+                "tie": format(second_tie,".2f"),
+                "secure": second_secure,
+                "difficulty": format(second_difficulty,".0f"),
+                "certitude": format(second_certitude,".0f"),
+                "prediction": format(second_prediction,".0f"),
+            },
+            {
+                "colour": third,
+                "victory_points": third_vp,
+                "point_diff": third_point_diff,
+                "vs_team": first,
+                "vp_ratio": format(third_vp_ratio,".2f"),
+                "tie": format(third_tie,".2f"),
+                "secure": third_secure,
+                "difficulty": format(third_difficulty,".0f"),
+                "certitude": format(third_certitude,".0f"),
+                "prediction": format(third_prediction,".0f"),
+            }
+        ]
         
+        match['results'] = team_results
 
-        match["results"]["second_vp"] = second_vp
-        match["results"]["second_point_diff"] = second_point_diff
-        match["results"]["second_vp_ratio"] = format(second_vp_ratio,".2f")
-        match["results"]["second_tie"] = format(second_tie,".2f")
-        match["results"]["second_secure"] = second_secure
-        match["results"]["second_difficulty"] = format(second_difficulty,".0f")
-        match["results"]["second_difficulty_max"] = format(100-second_difficulty,".0f")
-        match["results"]["second_prediction"] = format(second_prediction,".0f")
-        match["results"]["second_certitude"] = format(second_certitude,".2f")
-
-        match["results"]["third_vp"] = third_vp
-        match["results"]["third_point_diff"] = third_point_diff
-        match["results"]["third_vp_ratio"] = format(third_vp_ratio,".2f")
-        match["results"]["third_tie"] = format(third_tie,".2f")
-        match["results"]["third_secure"] = third_secure
-        match["results"]["third_difficulty"] = format(third_difficulty,".0f")
-        match["results"]["second_difficulty_max"] = format(100-third_difficulty,".0f")
-        match["results"]["third_prediction"] = format(third_prediction,".0f")
-        match["results"]["third_certitude"] = format(third_certitude,".2f")

--- a/api/templates/homepage.html
+++ b/api/templates/homepage.html
@@ -118,54 +118,35 @@
               align-items: flex-end;
             "
           >
+
+          {% for result in match['results'] %}
             <p>
-              <b class="green" id="{{match['all_worlds']['green'][0]}}"
-                >{{world_title(worlds_by_id[match['all_worlds']['green'][0]])}}</b
+              <b class="{{result['colour']}}" id="{{match['all_worlds'][result['colour']][0]}}"
+                >{{world_title(worlds_by_id[match['all_worlds'][result['colour']][0]])}}</b
               ><br />
-              <b class="green" id="{{match['all_worlds']['green'][1]}}"
-                >{{world_title(worlds_by_id[match['all_worlds']['green'][1]]|default("N/A"))}}</b
+              <b class="{{result['colour']}}" id="{{match['all_worlds'][result['colour']][1]}}"
+                >{{world_title(worlds_by_id[match['all_worlds'][result['colour']][1]]|default("N/A"))}}</b
               ><br />
-              Victory Points: {{match['results']['first_vp']}}<br />
-              Victory Ratio: {{match['results']['first_vp_ratio']}}<br />
-              Prediction: {{match['results']['first_prediction']}}<br /><br />
-              🟢🥇 vs 🔴🥈: {{match['results']['first_point_diff']}}<br />
-              Homestretch: {{match['results']['first_tie']}}<br />
-              Difficulty: {{match['results']['first_difficulty']}}% -
-              {{match['results']['second_difficulty_max']}}%<br />
-              Certitude: {{match['results']['first_certitude']}}%<br />
+              Victory Points: {{result['victory_points']}}<br />
+              Victory Ratio: {{result['vp_ratio']}}<br />
+              Prediction: {{result['prediction']}}<br /><br />
+
+              {% if result['colour'] == 'green' %}🟢{% endif %}
+              {% if result['colour'] == 'red' %}🔴{% endif %}
+              {% if result['colour'] == 'blue' %}🔵{% endif %}
+              🥇 vs 
+              {% if result['vs_team'] == 'green' %}🟢{% endif %}
+              {% if result['vs_team'] == 'red' %}🔴{% endif %}
+              {% if result['vs_team'] == 'blue' %}🔵{% endif %}
+              🥈:
+              {{ result['point_diff'] }}<br />
+              Homestretch: {{result['tie']}}<br />
+              Difficulty: {{result['difficulty']}}% -
+              {{result['point_diff']}}%<br />
+              Certitude: {{result['certitude']}}%<br />
             </p>
-            <p>
-              <b class="red" id="{{match['all_worlds']['red'][0]}}"
-                >{{world_title(worlds_by_id[match['all_worlds']['red'][0]])}}</b
-              ><br />
-              <b class="red" id="{{match['all_worlds']['green'][1]}}"
-                >{{world_title(worlds_by_id[match['all_worlds']['red'][1]]|default("N/A"))}}</b
-              ><br />
-              Victory Points: {{match['results']['second_vp']}}<br />
-              Victory Ratio: {{match['results']['second_vp_ratio']}}%<br />
-              Prediction: {{match['results']['second_prediction']}}<br /><br />
-              🔴🥈 vs 🔵🥉: {{match['results']['second_point_diff']}}<br />
-              Homestretch: {{match['results']['second_tie']}}<br />
-              Difficulty: {{match['results']['second_difficulty']}}% -
-              {{match['results']['second_difficulty_max']}}%<br />
-              Certitude: {{match['results']['second_certitude']}}%<br />
-            </p>
-            <p>
-              <b class="blue" id="{{match['all_worlds']['blue'][0]}}"
-                >{{world_title(worlds_by_id[match['all_worlds']['blue'][0]])}}</b
-              ><br />
-              <b class="blue" id="{{match['all_worlds']['blue'][1]}}"
-                >{{world_title(worlds_by_id[match['all_worlds']['blue'][1]]|default("N/A"))}}</b
-              ><br />
-              Victory Points: {{match['results']['third_vp']}}<br />
-              Victory Ratio: {{match['results']['third_vp_ratio']}}%<br />
-              Prediction: {{match['results']['third_prediction']}}<br /><br />
-              🔵🥉 vs 🟢🥇: {{match['results']['third_point_diff']}}<br />
-              Homestretch: {{match['results']['third_tie']}}<br />
-              Difficulty: {{match['results']['third_difficulty']}}% -
-              {{match['results']['second_difficulty_max']}}%<br />
-              Certitude: {{match['results']['third_certitude']}}%<br />
-            </p>
+            {% endfor %}
+
           </div>
           <p><a href="#">⬆️Return to top</a></p>
         </article>


### PR DESCRIPTION
This fixes wrong teams for the `match_math.py` calculation, and how point diffs are compared. 

It also fixes gpt's display to show teams by order of position, but does not fix how gpt compares diffs (don't want to make manual changes to gpt's code)

Will request gpt to fix its own code